### PR TITLE
Use action-python-cache for proper caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Cache python artifacts
+      uses: anna-money/action-python-cache@v2
     - name: Install dependencies
       run: |
         make deps
@@ -49,6 +51,10 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: "3.10"
+    - name: Cache python artifacts
+      uses: anna-money/action-python-cache@v2
+      with:
+        prefix: deploy
     - name: Install dependencies
       run:
         python -m pip install -U pip wheel twine


### PR DESCRIPTION
Adopt `anna-money/action-python-cache@v2` on the runner-side pip jobs (`test`, `deploy`) to cut cold-cache load. Part of the org-wide Nexus-load reduction effort.

Note: this repo does not consume ANNA Nexus — deps install from public PyPI and the release publishes to public PyPI via token — so no nexus.dev→nexus.infra migration, Tailscale, or Docker changes apply here. Cache adoption is the only relevant transform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)